### PR TITLE
Savedata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 A package to read in Vicon data for analysis. This package can be used to read in a CSV file generated from 
-the Vicon motion capture system
+the Vicon motion capture system. It will automatically attempt to interpolate missing data, and can save data back to a csv.
 
 
 ## Dependence
@@ -42,6 +42,31 @@ cd AIM_Vicon
 git submodule init
 git submodule update
 ```
+
+##Usage
+
+### Reading Data
+Vicon automatically reads data from the provided file when constructed.
+The constructor accepts two flags: ``verbose`` (defaults to ``False``) and ``interpolate`` (defaults to ``True``).
+
+If ``verbose`` is set to ``True``, it will print status updates and warnings while reading data. 
+
+If ``interpolate`` is set to ``True``, it will attempt to interpolate missing data points. If ``interpolate`` is set to 
+``False``, or if a field cannot be interpolated, missing data points will be set to ``np.nan``.
+
+### Saving Data
+The ``Vicon.save()`` method will save the data previously read.
+It accepts three flags: ``filename``, which defaults to ``None``, ``verbose``, which defaults to ``False``, and
+``mark_interpolated``, which defaults to ``True``.
+
+If ``filename`` is not provided, it will default to the file path specified on construction. ***WARNING: Saving to a
+file will overwrite it.***
+
+``verbose`` controls whether or not the save method will print status updates and warnings.
+
+If ``mark_interpolated`` is set to ``True``, any values that were generated through interpolation will be preceded by '!'.
+Vicon is able to read this, and a future Vicon object reading this value will display a warning with ``verbose`` set to ``True``.
+
 
 ## Examples
 

--- a/Vicon.py
+++ b/Vicon.py
@@ -53,6 +53,7 @@ import Markers
 import pandas
 import numpy as np
 
+
 class Vicon(object):
 
     def __init__(self, file_path, verbose=False):
@@ -85,7 +86,7 @@ class Vicon(object):
 
         self._nan_dict = {}
 
-        self.data_dict = self.open_vicon_file(self._file_path, verbose)
+        self.data_dict = self.open_vicon_file(self._file_path, verbose=verbose)
         self._make_Accelerometers(verbose=verbose)
         self._make_EMGs(verbose=verbose)
         self._make_force_plates(verbose=verbose)
@@ -273,7 +274,6 @@ class Vicon(object):
         """
         return self._T_EMGs
 
-
     def _filter_dict(self, sensors, substring):
         """
         filter the dictionary
@@ -283,7 +283,6 @@ class Vicon(object):
         :type: list
         """
         return list(filter(lambda x: substring in x, sensors.keys()))
-
 
     def _make_model(self, verbose=False):
         """
@@ -307,7 +306,7 @@ class Vicon(object):
             sensors = self.data_dict["Devices"]
             keys = self._filter_dict(sensors, 'Force_Plate')  # + ['Combined Moment'] + ['Combined CoP']
 
-            if any("Force_Plate" in word for word in keys) :
+            if any("Force_Plate" in word for word in keys):
                 self._force_plates[1] = ForcePlate.ForcePlate("Force_Plate_1",
                                                               sensors["Force_Plate__Force_1"],
                                                               sensors["Force_Plate__Moment_1"],
@@ -317,7 +316,8 @@ class Vicon(object):
                                                               sensors["Force_Plate__Force_2"],
                                                               sensors["Force_Plate__Moment_2"],
                                                               sensors["Force_Plate__CoP_2"])
-                print "Force plate models generated"
+                if verbose:
+                    print "Force plate models generated"
             elif verbose:
                 print "No force plates"
         elif verbose:
@@ -340,7 +340,8 @@ class Vicon(object):
                 for e_key, t_key in zip(EMG_keys, T_EMG_keys):
                     self._T_EMGs[int(filter(str.isdigit, t_key))] = EMG.EMG(t_key, sensors[t_key]["EMG"])
                     self._EMGs[int(filter(str.isdigit, e_key))] = EMG.EMG(e_key, sensors[e_key]["IM EMG"])
-                print "EMG models generated"
+                if verbose:
+                    print "EMG models generated"
             elif verbose:
                 print "No EMGs"
         elif verbose:
@@ -357,7 +358,8 @@ class Vicon(object):
                 keys = self._filter_dict(sensors, 'IMU')
                 for key in keys:
                     self._IMUs[int(filter(str.isdigit, key))] = IMU.IMU(key, sensors[key])
-                print "IMU models Generated"
+                if verbose:
+                    print "IMU models Generated"
             elif verbose:
                 print "No IMUs"
         elif verbose:
@@ -382,13 +384,14 @@ class Vicon(object):
                 keys = self._filter_dict(sensors, 'Accel')
                 for key in keys:
                     self._accels[int(filter(str.isdigit, key))] = Accel.Accel(key, sensors[key])
-                print "Accel models generated"
+                if verbose:
+                    print "Accel models generated"
             elif verbose:
                 print "No Accels"
         elif verbose:
             print "A scan for Accels found no Devices"
 
-    def open_vicon_file(self, file_path, verbose=False):
+    def open_vicon_file(self, file_path, verbose=False, interpolate=True):
         """
         parses the Vicon sensor data into a dictionary
         :param file_path: file path
@@ -397,6 +400,8 @@ class Vicon(object):
         :rtype: dict
         """
         # open the file and get the column names, axis, and units
+        if verbose:
+            print "Reading data from file " + file_path
         with open(file_path, mode='r') as csv_file:
             reader = csv.reader(csv_file)
             raw_data = list(reader)
@@ -406,7 +411,8 @@ class Vicon(object):
         names, segs = self._seperate_csv_sections(raw_data)
 
         for index, output in enumerate(names):
-            data[output] = self._extract_values(raw_data, segs[index], segs[index + 1], verbose=verbose, category=output)
+            data[output] = self._extract_values(raw_data, segs[index], segs[index + 1], verbose=verbose,
+                                                category=output, interpolate=interpolate)
 
         return data
 
@@ -428,7 +434,7 @@ class Vicon(object):
         inx.append(len(raw_col))
         return fitlered_col, inx
 
-    def  _fix_col_names(self, names):
+    def _fix_col_names(self, names):
         fixed_names = []
         get_index = lambda x: x.index("Sensor") + 7
 
@@ -444,7 +450,7 @@ class Vicon(object):
 
                 index = name.index(":")
 
-                fixed_names.append(name[index+1:])
+                fixed_names.append(name[index + 1:])
 
             elif "AMTI" in name:
 
@@ -479,7 +485,7 @@ class Vicon(object):
 
         return fixed_names
 
-    def _extract_values(self, raw_data, start, end, verbose=False, category=""):
+    def _extract_values(self, raw_data, start, end, verbose=False, category="", interpolate=True):
         indices = {}
         data = {}
         current_name = None
@@ -518,12 +524,12 @@ class Vicon(object):
             for key, value in data.iteritems():
                 for sub_key, sub_value in value.iteritems():
                     index = indices[(key, sub_key)]
-                    if row[index] is '':
+                    if row[index] is '' or str(row[index]).lower() == "nan":
                         val = np.nan
                     elif '!' in row[index]:
                         val = float(row[index][1:])
                         if verbose and (key, sub_key) not in flags:
-                            print "Reading previously interpolated data in category " + category +\
+                            print "Reading previously interpolated data in category " + category + \
                                   ", subject " + key + ", field " + sub_key + "."
                             flags.append((key, sub_key))
                     else:
@@ -535,14 +541,14 @@ class Vicon(object):
                 #  No interpolation method can do anything with an array of NaNs,
                 #  so this way we save ourselves a bit of computation
                 nans = np.isnan(sub_value["data"])
-                if True in nans and False in nans:
+                if True in nans and False in nans and interpolate:
                     if category not in self._nan_dict:
                         self._nan_dict[category] = {}
                     if key not in self._nan_dict[category]:
                         self._nan_dict[category][key] = {}
                     self._nan_dict[category][key][sub_key] = nans
                     if verbose:
-                        print "Interpolating missing values in field " + sub_key + ", in subject " + key +\
+                        print "Interpolating missing values in field " + sub_key + ", in subject " + key + \
                               ", in category " + category + "..."
                     s = pandas.Series(sub_value["data"])
                     #  Akima interpolation only covers interior NaNs,
@@ -567,6 +573,10 @@ class Vicon(object):
             arr.append(False)
         return arr
 
+    def _len_data(self, category):
+        """Returns the length of the data section of a given category"""
+        return len(next(next(self.data_dict[category].itervalues()).itervalues())["data"])
+
     def save(self, filename=None, verbose=False, mark_interpolated=True):
         file_path = self._file_path
         if filename is not None:
@@ -575,11 +585,110 @@ class Vicon(object):
             print "Saving data to " + file_path + ". Interpolated values will be marked with '!'."
         if verbose and not mark_interpolated:
             print "Saving data to " + file_path + ". Interpolated values will not be marked."
+        with open(file_path, "wb") as f:
+            f.seek(0)
+            f.truncate()
+            writer = csv.writer(f)
+            for category, subjects in self.data_dict.iteritems():  # for every category in the data...
+                if verbose:
+                    print "Saving category " + category + "..."
+                #  write the header
+                writer.writerow([category])
+                if category == "Devices":
+                    writer.writerow([1000])  # Devices section has 1000 (units??) framerate
+                else:
+                    writer.writerow([100])  # unlike all other sections, with 100 framerate
+                # writer.writerow(["", ""])
 
+                line = ["", ""]
+                for subject, fields in subjects.iteritems():  # for every subject...
+                    line.append(subject)
+                    if len(fields) > 1:  # if the subject has at least two fields...
+                        for i in range(len(fields) - 1):
+                            line.append("")  # add empty space between subject names to make room for fields
+                writer.writerow(line)
 
+                line = ["Frame", "Sub Frame"]
+                for subject, fields in subjects.iteritems():
+                    for field, f_vals in fields.iteritems():
+                        line.append(field)  # add name of each field
+                writer.writerow(line)
+
+                line = ["", ""]
+                for subject, fields in subjects.iteritems():
+                    for field, f_vals in fields.iteritems():
+                        line.append(f_vals["unit"])  # add unit for each field
+                writer.writerow(line)
+
+                #  Time to write the data!
+                for i in range(self._len_data(category)):
+                    if category == "Devices":
+                        frame = (i / 10) + 1
+                        sub = i % 10
+                    else:
+                        frame = i + 1
+                        sub = 0
+                    line = [frame, sub]
+
+                    for subject, fields in subjects.iteritems():
+                        for field, f_vals in fields.iteritems():
+                            x = f_vals["data"][i]
+                            if mark_interpolated and self._nan_dict[category][subject][field][i]:
+                                x = "!" + str(x)
+                            elif np.isnan(x):
+                                x = ""
+                            line.append(x)
+                    writer.writerow(line)
+                writer.writerow(["", ""])
+        if verbose:
+            print "Saved!"
+
+    def __eq__(self, other):
+        return isinstance(other, Vicon) and self.data_dict == other.data_dict
+
+    def find_ineq(self, other):
+        """
+        Method to help find differences between different Vicon objects.
+        """
+        if not isinstance(other, Vicon):
+            print "Not Vicon!"
+            return
+        print "Scanning data for differences..."
+        flag = False
+        for category, subjects in self.data_dict.iteritems():
+            if category not in other.data_dict:
+                print "Category " + category + " missing!"
+                flag = True
+            for subject, fields in subjects.iteritems():
+                if subject not in other.data_dict[category]:
+                    print "Subject " + subject + " in category " + category + " missing!"
+                    flag = True
+                for field, f_vals in fields.iteritems():
+                    if field not in other.data_dict[category][subject]:
+                        flag = True
+                        print "Field " + field + " of subject " + subject + " in category " + category + " missing!"
+                    elif len(f_vals["data"]) != len(other.data_dict[category][subject][field]["data"]):
+                        flag = True
+                        print "Data length mismatch in field " + field \
+                              + " of subject " + subject + " in category " + category + "!"
+                    elif set(f_vals["data"]) != set(other.data_dict[category][subject][field]["data"]):
+                        flag = True
+                        print "Data mismatch in field " + field \
+                              + " of subject " + subject + " in category " + category + "!"
+                    elif f_vals["data"] != other.data_dict[category][subject][field]["data"]:
+                        flag = True
+                        print "Data order mismatch in field " + field \
+                              + " of subject " + subject + " in category " + category + "!"
+
+                    if field in other.data_dict[category][subject] and f_vals["unit"] != \
+                            other.data_dict[category][subject][field]["unit"]:
+                        flag = True
+                        print "Unit mismatch in field " + field \
+                              + " of subject " + subject + " in category " + category + "!"
+        if not flag:
+            print "No differences detected!"
 
 
 if __name__ == '__main__':
     file = "/home/nathaniel/AIM_GaitData/Gaiting_stairs/subject_08/subject_08_walking_01.csv"
     data = Vicon(file)
-

--- a/Vicon.py
+++ b/Vicon.py
@@ -64,13 +64,34 @@ class Vicon(object):
         self._force_plates = {}
         self._IMUs = {}
         self._accels = {}
+
+        #  nan_dict is a dictionary with the same format of data_dict,
+        #  but it keeps track of the positions of nans that get interpolated.
+
+        #  data is accessed through nan_dict[category][subject][field],
+        #  where nan_dict contains category iff there is at least one valid subject for the category,
+        #  nan_dict[category] contains subject iff there is at least one valid field for the subject, and
+        #  nan_dict[category][subject] contains field iff data_dict[category][subject][field]["data"] exists.
+
+        #  nan_dict[category][subject][field] is a boolean array where
+        #  nan_dict[category][subject][field] = np.isnan(data_dict[category][subject][field]["data"])
+        #  or, nan_dict[category][subject][field][n] = np.isnan(data_dict[category][subject][field]["data"][n])
+        #  iff data_dict[category][subject][field]["data"] contained missing values that were interpolated.
+
+        #  if data_dict[category][subject][field]["data"] did not contain any missing values,
+        #  or if data_dict[category][subject][field]["data"] consisted solely of nans,
+        #  nan_dict[category][subject][field] is an array consisting only of False,
+        #  where len(nan_dict[category][subject][field]) = len(data_dict[category][subject][field]["data"])
+
+        self._nan_dict = {}
+
         self.data_dict = self.open_vicon_file(self._file_path, verbose)
-        self._make_Accelerometers()
-        self._make_EMGs()
-        self._make_force_plates()
-        self._make_IMUs()
+        self._make_Accelerometers(verbose=verbose)
+        self._make_EMGs(verbose=verbose)
+        self._make_force_plates(verbose=verbose)
+        self._make_IMUs(verbose=verbose)
         self._make_marker_trajs()
-        self._make_model()
+        self._make_model(verbose=verbose)
 
     def _find_number_of_frames(self, col):
         """
@@ -264,17 +285,18 @@ class Vicon(object):
         return list(filter(lambda x: substring in x, sensors.keys()))
 
 
-    def _make_model(self):
+    def _make_model(self, verbose=False):
         """
         generates a model from the model outputs
         :return:
         """
         if "Model Outputs" in self.data_dict:
             self._model_output = ModelOutput.ModelOutput(self.data_dict["Model Outputs"], self.joint_names)
-        else:
+            print "Model Outputs generated"
+        elif verbose:
             print "No Model outputs"
 
-    def _make_force_plates(self):
+    def _make_force_plates(self, verbose=False):
         """
         generate force plate models
         :return: None
@@ -294,15 +316,16 @@ class Vicon(object):
                                                               sensors["Force_Plate__Force_2"],
                                                               sensors["Force_Plate__Moment_2"],
                                                               sensors["Force_Plate__CoP_2"])
-            else:
+                print "Force plate models generated"
+            elif verbose:
                 print "No force plates"
-        else:
-            print "No Devices"
+        elif verbose:
+            print "A scan for force plates found no Devices"
 
     def _make_markers(self):
         markers = self.data_dict["Trajectories"]
 
-    def _make_EMGs(self):
+    def _make_EMGs(self, verbose=False):
         """
         generate EMG models
         :return: None
@@ -316,12 +339,13 @@ class Vicon(object):
                 for e_key, t_key in zip(EMG_keys, T_EMG_keys):
                     self._T_EMGs[int(filter(str.isdigit, t_key))] = EMG.EMG(t_key, sensors[t_key]["EMG"])
                     self._EMGs[int(filter(str.isdigit, e_key))] = EMG.EMG(e_key, sensors[e_key]["IM EMG"])
-            else:
+                print "EMG models generated"
+            elif verbose:
                 print "No EMGs"
-        else:
-            print "No Devices"
+        elif verbose:
+            print "A scan for EMGs found no Devices"
 
-    def _make_IMUs(self):
+    def _make_IMUs(self, verbose=False):
         """
         generate IMU models
         :return: None
@@ -332,10 +356,11 @@ class Vicon(object):
                 keys = self._filter_dict(sensors, 'IMU')
                 for key in keys:
                     self._IMUs[int(filter(str.isdigit, key))] = IMU.IMU(key, sensors[key])
-            else:
+                print "IMU models Generated"
+            elif verbose:
                 print "No IMUs"
-        else:
-            print "No Devices"
+        elif verbose:
+            print "A scan for IMUs found no Devices"
 
     def _make_marker_trajs(self):
         """
@@ -345,7 +370,7 @@ class Vicon(object):
         self._markers = Markers.Markers(self.data_dict["Trajectories"])
         self._markers.make_markers()
 
-    def _make_Accelerometers(self):
+    def _make_Accelerometers(self, verbose=False):
         """
         generate the accel objects
         :return: None
@@ -356,15 +381,17 @@ class Vicon(object):
                 keys = self._filter_dict(sensors, 'Accel')
                 for key in keys:
                     self._accels[int(filter(str.isdigit, key))] = Accel.Accel(key, sensors[key])
-            else:
+                print "Accel models generated"
+            elif verbose:
                 print "No Accels"
-        else:
-            print "No Devices"
+        elif verbose:
+            print "A scan for Accels found no Devices"
 
     def open_vicon_file(self, file_path, verbose=False):
         """
         parses the Vicon sensor data into a dictionary
         :param file_path: file path
+        :param verbose: prints debug statements if True
         :return: dictionary of the sensors
         :rtype: dict
         """
@@ -378,7 +405,7 @@ class Vicon(object):
         names, segs = self._seperate_csv_sections(raw_data)
 
         for index, output in enumerate(names):
-            data[output] = self._extract_values(raw_data, segs[index], segs[index + 1], verbose)
+            data[output] = self._extract_values(raw_data, segs[index], segs[index + 1], verbose=verbose, category=output)
 
         return data
 
@@ -451,7 +478,7 @@ class Vicon(object):
 
         return fixed_names
 
-    def _extract_values(self, raw_data, start, end, verbose=False):
+    def _extract_values(self, raw_data, start, end, verbose=False, category=""):
         indices = {}
         data = {}
         current_name = None
@@ -483,6 +510,7 @@ class Vicon(object):
 
         # Put all the data in the correct sub dictionary.
 
+        flags = []
         for row in raw_data[start + 5:end - 1]:
 
             frame = int(row[0])
@@ -491,17 +519,30 @@ class Vicon(object):
                     index = indices[(key, sub_key)]
                     if row[index] is '':
                         val = np.nan
+                    elif '!' in row[index]:
+                        val = float(row[index][1:])
+                        if verbose and (key, sub_key) not in flags:
+                            print "Reading previously interpolated data in category " + category +\
+                                  ", subject " + key + ", field " + sub_key + "."
+                            flags.append((key, sub_key))
                     else:
                         val = float(row[index])
                     sub_value["data"].append(val)
         for key, value in data.iteritems():  # For every subject in the data...
             for sub_key, sub_value in value.iteritems():  # For each field under each subject...
-                #  If we have NaNs *and* the whole row isn't NaNs...
+                #  If we have NaNs and the whole row isn't NaNs...
                 #  No interpolation method can do anything with an array of NaNs,
                 #  so this way we save ourselves a bit of computation
-                if True in np.isnan(sub_value["data"]) and False in np.isnan(sub_value["data"]):
+                nans = np.isnan(sub_value["data"])
+                if True in nans and False in nans:
+                    if category not in self._nan_dict:
+                        self._nan_dict[category] = {}
+                    if key not in self._nan_dict[category]:
+                        self._nan_dict[category][key] = {}
+                    self._nan_dict[category][key][sub_key] = nans
                     if verbose:
-                        print "Interpolating missing values in field " + sub_key + ", in subject " + key + "..."
+                        print "Interpolating missing values in field " + sub_key + ", in subject " + key +\
+                              ", in category " + category + "..."
                     s = pandas.Series(sub_value["data"])
                     #  Akima interpolation only covers interior NaNs,
                     #  and splines are *way* too imprecise with unset boundary conditions,
@@ -509,8 +550,30 @@ class Vicon(object):
                     s = s.interpolate(method='akima', limit_direction='both')
                     s = s.interpolate(method='linear', limit_direction='both')
                     sub_value["data"] = s.to_list()
+                else:
+                    if category not in self._nan_dict:
+                        self._nan_dict[category] = {}
+                    if key not in self._nan_dict[category]:
+                        self._nan_dict[category][key] = {}
+                    self._nan_dict[category][key][sub_key] = self._false_of_n(len(sub_value["data"]))
 
         return data
+
+    def _false_of_n(self, n):
+        """Helper function to generate an array of Falses of length N"""
+        arr = []
+        for i in range(n):
+            arr.append(False)
+        return arr
+
+    def save(self, filename=None, verbose=False, mark_interpolated=True):
+        file_path = self._file_path
+        if filename is not None:
+            file_path = filename
+        if verbose and mark_interpolated:
+            print "Saving data to " + file_path + ". Interpolated values will be marked with '!'."
+        if verbose and not mark_interpolated:
+            print "Saving data to " + file_path + ". Interpolated values will not be marked."
 
 
 

--- a/Vicon.py
+++ b/Vicon.py
@@ -292,7 +292,8 @@ class Vicon(object):
         """
         if "Model Outputs" in self.data_dict:
             self._model_output = ModelOutput.ModelOutput(self.data_dict["Model Outputs"], self.joint_names)
-            print "Model Outputs generated"
+            if verbose:
+                print "Model Outputs generated"
         elif verbose:
             print "No Model outputs"
 

--- a/Vicon.py
+++ b/Vicon.py
@@ -56,7 +56,7 @@ import numpy as np
 
 class Vicon(object):
 
-    def __init__(self, file_path, verbose=False):
+    def __init__(self, file_path, verbose=False, interpolate=True):
         self._file_path = file_path
         self.joint_names = ["Ankle", "Knee", "Hip"]
         self._number_of_frames = 0
@@ -86,7 +86,7 @@ class Vicon(object):
 
         self._nan_dict = {}
 
-        self.data_dict = self.open_vicon_file(self._file_path, verbose=verbose)
+        self.data_dict = self.open_vicon_file(self._file_path, verbose=verbose, interpolate=interpolate)
         self._make_Accelerometers(verbose=verbose)
         self._make_EMGs(verbose=verbose)
         self._make_force_plates(verbose=verbose)


### PR DESCRIPTION
 - Vicon now can save data into .csv files!
``Vicon.save(filename=None, verbose=False, mark_interpolated=True)``
 - if configured to mark interpolated values, such values will be preceded by '!'.
 - Vicon is now slightly more robust when reading data - "nan" and "NaN" are now saved as ``np.nan``
 - Values marked with '!' are recognized as having previously been interpolated.
 - All prints are behind verbose gates, and have been touched up slightly
 - Interpolation can be toggled on/off in the constructor, using the new ``interpolate`` flag (defaults to True)