### PR TITLE
Joint Calculations

### DIFF
--- a/Markers.py
+++ b/Markers.py
@@ -310,9 +310,9 @@ class Markers(object):
         joints_points = []
         fps = 100  # Frame per sec
         keys = self._filtered_markers.keys()
-        nfr = len(self._filtered_markers[keys[0]])  # Number of frames
+        nfr = len(self._filtered_markers[list(keys)[0]])  # Number of frames
 
-        for frame in xrange(nfr):
+        for frame in range(nfr):
             x = []
             y = []
             z = []

--- a/Markers.py
+++ b/Markers.py
@@ -246,10 +246,10 @@ class Markers(object):
         :param bodies: list transformation
         :return:
         """
-        for name, value in self._rigid_body.iteritems():
+        for name, value in self._rigid_body.items():
             frames = []
             if name in bodies:
-                for ii in xrange(len(value[0])):
+                for ii in range(len(value[0])):
                         frames.append(cloud_to_cloud(bodies[name], [value[0][ii], value[1][ii], value[2][ii], value[3][ii]])[0])
                 self.add_frame(name, frames)
 
@@ -641,7 +641,7 @@ def cloud_to_cloud(A_, B_):
 
     T = np.zeros((4, 4))
     T[:3, :3] = R
-    for ii in xrange(3):
+    for ii in range(3):
         T[ii, 3] = p[ii]
     T[3, 3] = 1.0
 
@@ -829,7 +829,7 @@ def get_rmse(marker_set, body):
     :return:
     """
     error = []
-    for frame in xrange(1000):
+    for frame in range(1000):
         f = [body[0][frame], body[1][frame], body[2][frame], body[frame]]
         T, err = Markers.cloud_to_cloud(marker_set, f)
         error.append(err)

--- a/Markers.py
+++ b/Markers.py
@@ -72,6 +72,7 @@ class Markers(object):
         self._frames = {}
         self._filter_window = 10
         self._filtered_markers = {}
+        self._joints = {}
 
     @property
     def marker_names(self):
@@ -142,7 +143,7 @@ class Markers(object):
             # if value_name.keys()[0] == "Magnitude( X )" or value_name.keys()[0] == "Count":
             #     continue
 
-            if "Magnitude( X )" in  value_name.keys()or "Count" in value_name.keys():
+            if "Magnitude( X )" in value_name.keys() or "Count" in value_name.keys():
                 continue
 
             x_arr = value_name["X"]["data"]
@@ -161,17 +162,12 @@ class Markers(object):
                 point = core.Point.Point(x_filt[inx], y_filt[inx], z_filt[inx])
                 self._filtered_markers[fixed_name].append(point)
 
-
-
     def set_ground_plane(self, rigid_body, offset_height=14):
 
         markers = self.get_rigid_body("marker_names")
         fit, residual = fit_to_plane(markers)
 
-
-
         pass
-
 
     def smart_sort(self, filter=True):
         """
@@ -250,8 +246,29 @@ class Markers(object):
             frames = []
             if name in bodies:
                 for ii in range(len(value[0])):
-                        frames.append(cloud_to_cloud(bodies[name], [value[0][ii], value[1][ii], value[2][ii], value[3][ii]])[0])
+                    frames.append(
+                        cloud_to_cloud(bodies[name], [value[0][ii], value[1][ii], value[2][ii], value[3][ii]])[0])
                 self.add_frame(name, frames)
+
+    def calc_joints(self):
+        """
+        Calculates all lower body joints automatically
+        :return:
+        """
+        self._joints["L_Hip"] = self.calc_l_hip()
+        self._joints["R_Hip"] = self.calc_r_hip()
+        self._joints["L_Knee"] = self.calc_l_knee()
+        self._joints["R_Knee"] = self.calc_r_knee()
+        self._joints["L_Ankle"] = self.calc_l_ankle()
+        self._joints["R_Ankle"] = self.calc_r_ankle()
+
+    def get_joint(self, name):
+        """
+        Get a joint
+        :param name: Name of the joint
+        :return: joint
+        """
+        return self._joints[name]
 
     def get_frame(self, name):
         """
@@ -292,11 +309,130 @@ class Markers(object):
         local_joint = np.array([[0.0], [0.0], [0.0], [0.0]])
 
         for T in Tp:
-            local_joint += transform_vector(np.linalg.pinv(T), global_joint )/len(Tp)
+            local_joint += transform_vector(np.linalg.pinv(T), global_joint) / len(Tp)
 
         return np.vstack((global_joint, [1])), axis, local_joint
 
-    def play(self, joints=None, save=False, name="im"):
+    def _calc_ball_joint(self, parent, child):
+        """
+        Calculates the location of a ball joint between the parent and child rigid bodies.
+        :param parent: Name of the parent rigid body (Ex: Root)
+        :param child: Name of the child rigid body (Ex: L_Femur)
+        :return: 2D array of every position of the ball joint for every frame. Array at index frame is [x, y, z].
+        """
+        child = self.get_rigid_body(child)
+        parent_frame = self.get_frame(parent)
+        frames = len(child[0])
+
+        # Obtain the locations of the child markers relative to the Parent rigid body
+        child_by_parent = [[global_point_to_frame(parent_frame[n], child[i][n]) for n in range(frames)] for i in range(4)]
+        # Identical to child except for the difference in frame of reference
+        # Points are accessed through child_by_parent[marker][frame]
+
+        # Calculate the location of the center of rotation of child relative to the parent, over the entire dataset
+        jointraw = calc_CoR(child_by_parent)
+        # calc_CoR requires that the moving body be rotating around a stationary ball joint.
+        # By switching to the parent's reference frame, we can pretend as if the joint is stationary
+
+        joint = []
+        for n in range(frames):  # Convert back from the hip's frame to the global frame
+            jointn_global = local_point_to_global(parent_frame[n], core.Point.vector_to_point(jointraw))
+            joint.append([jointn_global.x, jointn_global.y, jointn_global.z])
+
+        return joint
+
+    def _calc_hinge_joint(self, parent, child):
+        """
+        Calculates the location of a hinge joint (i.e. a knee joint) between the parent and child rigid bodies
+        :param parent: Name of the parent rigid body (Ex: L_Femur)
+        :param child: Name of the child rigid body (Ex: L_Tibia)
+        :return: 2D array of every position of the center of the hinge joint for every frame. Array at index frame is [x, y, z].
+        """
+        child = self.get_rigid_body(child)
+        parent_frame = self.get_frame(parent)
+        parent = self.get_rigid_body(parent)
+
+        frames = len(child[0])
+
+        child_by_parent = [[global_point_to_frame(parent_frame[n], child[i][n]) for n in range(frames)] for i in range(4)]
+        parent_by_parent = [[global_point_to_frame(parent_frame[n], parent[i][n]) for n in range(frames)] for i in range(4)]
+
+        # calc_CoR isn't meant to be used with hinge joints
+        # It still gives us a point, but the location of this joint is poorly defined along the axis of rotation
+        jointraw = calc_CoR(child_by_parent)
+
+        # calc_AoR gives us the slope of the axis of rotation
+        # Between this and calc_CoR, we can define the line representing the AoR
+        # From there, finding the actual joint is just a matter of finding the point on the line
+        # that is the closest to both the child and the parent
+        jointaxisraw = calc_AoR(child_by_parent)
+
+        joint_by_parent = []
+        for frame in range(frames):  # Find the location on the AoR that is closest to both relevant rigid bodies
+            l_parentn_local = [parent_by_parent[n][frame] for n in range(4)]
+            l_parentn_local = [[n.x, n.y, n.z] for n in l_parentn_local]
+
+            l_childn_local = [child_by_parent[n][frame] for n in range(4)]
+            l_childn_local = [[n.x, n.y, n.z] for n in l_childn_local]
+
+            l_jointn_local = minimize_center(l_childn_local+l_parentn_local, jointaxisraw, [jointraw[0][0], jointraw[1][0], jointraw[2][0]])
+            joint_by_parent.append(l_jointn_local)
+
+        joint = []
+        for n in range(frames):
+            p = core.Point.Point(joint_by_parent[n].x[0], joint_by_parent[n].x[1], joint_by_parent[n].x[2])
+            l_jointn_global = local_point_to_global(parent_frame[n], p)
+            joint.append([l_jointn_global.x, l_jointn_global.y, l_jointn_global.z])
+
+        return joint
+
+    def calc_l_hip(self):
+        """
+        Calculates the location of the left hip.
+        :return: 2D array representing the location of the joint through time.
+        """
+
+        return self._calc_ball_joint("Root", "L_Femur")
+
+    def calc_r_hip(self):
+        """
+        Calculates the location of the right hip.
+        :return: 2D array representing the location of the joint through time.
+        """
+
+        return self._calc_ball_joint("Root", "R_Femur")
+
+    def calc_l_knee(self):
+        """
+        Calculates the location of the left knee.
+        :return: 2D array representing the location of the joint through time.
+        """
+
+        return self._calc_hinge_joint("L_Femur", "L_Tibia")
+
+    def calc_r_knee(self):
+        """
+        Calculates the location of the right knee.
+        :return: 2D array representing the location of the joint through time.
+        """
+
+        return self._calc_hinge_joint("R_Femur", "R_Tibia")
+
+    def calc_l_ankle(self):
+        """
+        Calculates the location of the left ankle.
+        :return: 2D array representing the location of the joint through time.
+        """
+        return self._calc_ball_joint("L_Tibia", "L_Foot")
+
+    def calc_r_ankle(self):
+        """
+        Calculates the location of the right ankle.
+        :return: 2D array representing the location of the joint through time.
+        """
+        return self._calc_ball_joint("R_Tibia", "R_Foot")
+
+    def play(self, joints=False, save=False, name="im"):
         """
         play an animation of the         markers
         :param joints: opital param for joint centers
@@ -327,11 +463,16 @@ class Markers(object):
             x = []
             y = []
             z = []
-            if joints is not None:
-                for joint in joints:
-                    x.append(joint[frame][0])
-                    y.append(joint[frame][1])
-                    z.append(joint[frame][2])
+            if joints:
+                for jointname, joint in self._joints.items():
+                    if frame < len(joint):
+                        x.append(joint[frame][0])
+                        y.append(joint[frame][1])
+                        z.append(joint[frame][2])
+                    else:
+                        x.append(joint[len(joint) - 1][0])
+                        y.append(joint[len(joint) - 1][1])
+                        z.append(joint[len(joint) - 1][2])
                 joints_points.append([x, y, z])
 
         self._fig = plt.figure()
@@ -365,7 +506,7 @@ class Markers(object):
         self._ax.set_xlabel('X Label')
         self._ax.set_ylabel('Y Label')
         self._ax.set_zlabel('Z Label')
-        self._ax.axis([-500, 500, -200, 3000])
+        self._ax.axis([-500, 500, -500, 500])
         self._ax.set_zlim3d(0, 1250)
         self._ax.scatter(x[frame], y[frame], z[frame], c='r', marker='o')
         if len(centers) > 0:
@@ -389,6 +530,28 @@ def transform_markers(transforms, markers):
             adjusted_locations.append(new_marker)
         trans_markers.append(adjusted_locations)
     return trans_markers
+
+
+def global_to_frame(frame, global_vector):
+    """Transforms a vector in the global frame to the provided frame."""
+    return transform_vector(np.linalg.pinv(frame), global_vector)
+
+
+def global_point_to_frame(frame, global_point):
+    """Transforms a Point object from the global frame to the provided frame."""
+    return core.Point.vector_to_point(global_to_frame(frame, core.Point.point_to_vector(global_point)))
+
+
+def frame_to_global(frame, local_vector):
+    """Transforms a vector in the provided local frame to the global frame."""
+    return transform_vector(frame, local_vector)
+
+
+def local_point_to_global(frame, local_point):
+    """Transforms a Point object in the provided local frame to the global frame."""
+    return core.Point.vector_to_point(frame_to_global(frame, core.Point.point_to_vector(local_point)))
+
+
 
 def make_frame(markers):
     """
@@ -477,10 +640,11 @@ def batch_transform_vector(frames, vector):
 
     for T in frames:
         p = np.dot(T, vector)
-        #p = np.dot(np.eye(4), vector)
+        # p = np.dot(np.eye(4), vector)
         trans_vectors.append(p)
 
     return trans_vectors
+
 
 def unit_vector(vector):
     """
@@ -542,7 +706,8 @@ def calc_AoR(markers):
     :rtype np.array
     """
     A = __calc_A(markers)  # calculates the A matrix
-    E_vals, E_vecs = np.linalg.eig(A)  # I believe that the np function eig has a different output than the matlab function eigs
+    E_vals, E_vecs = np.linalg.eig(
+        A)  # I believe that the np function eig has a different output than the matlab function eigs
     min_E_val_idx = np.argmin(E_vals)
     axis = E_vecs[:, min_E_val_idx]
     return axis
@@ -644,7 +809,6 @@ def cloud_to_cloud(A_, B_):
     for ii in range(3):
         T[ii, 3] = p[ii]
     T[3, 3] = 1.0
-
 
     return T, rmse
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This package can be installed via pip:
 pip install git+https://github.com/WPI-AIM/AIM_Vicon.git
 ```
 
+(If you have both Python 2 and Python 3 installed you'll need to specify `pip3` - `pip` defaults to Python 2 if installed.)
+
 ##Usage
 
 ### Vicon

--- a/Vicon.py
+++ b/Vicon.py
@@ -55,9 +55,10 @@ import EMG
 import Markers
 import IMU
 
+
 class Vicon(object):
 
-    def __init__(self, file_path, verbose=False, interpolate=True, maxnanstotal=-1, maxnansrow=-1):
+    def __init__(self, file_path, verbose=False, interpolate=True, maxnanstotal=-1, maxnansrow=-1, sanitize=True):
         self._file_path = file_path
         self.joint_names = ["Ankle", "Knee", "Hip"]
         self._number_of_frames = 0
@@ -87,7 +88,8 @@ class Vicon(object):
 
         self._nan_dict = {}
 
-        self.data_dict = self.open_vicon_file(self._file_path, verbose=verbose, interpolate=interpolate, maxnanstotal=maxnanstotal, maxnansrow=maxnansrow)
+        self.data_dict = self.open_vicon_file(self._file_path, verbose=verbose, interpolate=interpolate,
+                                              maxnanstotal=maxnanstotal, maxnansrow=maxnansrow, sanitize=sanitize)
         self._make_Accelerometers(verbose=verbose)
         self._make_EMGs(verbose=verbose)
         self._make_force_plates(verbose=verbose)
@@ -360,11 +362,11 @@ class Vicon(object):
                 for key in keys:
                     self._IMUs[int(filter(str.isdigit, key))] = IMU.IMU(key, sensors[key])
                 if verbose:
-                    print( "IMU models Generated")
+                    print("IMU models Generated")
             elif verbose:
-                print ("No IMUs")
+                print("No IMUs")
         elif verbose:
-            print( "A scan for IMUs found no Devices")
+            print("A scan for IMUs found no Devices")
 
     def _make_marker_trajs(self):
         """
@@ -386,13 +388,13 @@ class Vicon(object):
                 for key in keys:
                     self._accels[int(filter(str.isdigit, key))] = Accel.Accel(key, sensors[key])
                 if verbose:
-                    print( "Accel models generated")
+                    print("Accel models generated")
             elif verbose:
-                print ("No Accels")
+                print("No Accels")
         elif verbose:
-            print ("A scan for Accels found no Devices")
+            print("A scan for Accels found no Devices")
 
-    def open_vicon_file(self, file_path, verbose=False, interpolate=True, maxnanstotal=-1, maxnansrow=-1):
+    def open_vicon_file(self, file_path, verbose=False, interpolate=True, maxnanstotal=-1, maxnansrow=-1, sanitize=True):
         """
         parses the Vicon sensor data into a dictionary
         :param file_path: file path
@@ -402,7 +404,7 @@ class Vicon(object):
         """
         # open the file and get the column names, axis, and units
         if verbose:
-            print( "Reading data from file " + file_path)
+            print("Reading data from file " + file_path)
         with open(file_path, mode='r') as csv_file:
             reader = csv.reader(csv_file)
             raw_data = list(reader)
@@ -413,7 +415,8 @@ class Vicon(object):
 
         for index, output in enumerate(names):
             data[output] = self._extract_values(raw_data, segs[index], segs[index + 1], verbose=verbose,
-                                                category=output, interpolate=interpolate, maxnanstotal=maxnanstotal, maxnansrow=maxnansrow)
+                                                category=output, interpolate=interpolate, maxnanstotal=maxnanstotal,
+                                                maxnansrow=maxnansrow, sanitize=sanitize)
 
         return data
 
@@ -493,7 +496,8 @@ class Vicon(object):
 
         return fixed_names
 
-    def _extract_values(self, raw_data, start, end, verbose=False, category="", interpolate=True, maxnanstotal=-1, maxnansrow=-1):
+    def _extract_values(self, raw_data, start, end, verbose=False, category="", interpolate=True, maxnanstotal=-1,
+                        maxnansrow=-1, sanitize=True):
         indices = {}
         data = {}
         current_name = None
@@ -609,7 +613,7 @@ class Vicon(object):
                         self._nan_dict[category][key] = {}
                     self._nan_dict[category][key][sub_key] = nans
                     if verbose:
-                        print ("Interpolating missing values in field " + sub_key + ", in subject " + key + \
+                        print("Interpolating missing values in field " + sub_key + ", in subject " + key + \
                               ", in category " + category + "...")
                     s = pandas.Series(sub_value["data"])
                     #  Akima interpolation only covers interior NaNs,
@@ -619,12 +623,18 @@ class Vicon(object):
                         s = s.interpolate(method='akima', limit_direction='both')
                     except ValueError:
                         if verbose:
-                            print ("Akima Interpolation failed for field " + sub_key + ", in subject " + key + \
+                            print("Akima Interpolation failed for field " + sub_key + ", in subject " + key + \
                                   ", in category " + category + "!")
-                            print ("Falling back to linear interpolation...")
+                            print("Falling back to linear interpolation...")
                     s = s.interpolate(method='linear', limit_direction='both')
                     sub_value["data"] = s.to_list()
                 else:
+                    if False not in nans:
+                        if verbose:
+                            print("Could not interpolate field " + sub_key + ", in subject " + key + \
+                                  ", in category " + category + ", as all values were nans!")
+                        if sanitize:
+                            sub_value["data"] = [0 for i in range(len(sub_value["data"]))]
                     if category not in self._nan_dict:
                         self._nan_dict[category] = {}
                     if key not in self._nan_dict[category]:
@@ -649,16 +659,16 @@ class Vicon(object):
         if filename is not None:
             file_path = filename
         if verbose and mark_interpolated:
-            print ("Saving data to " + file_path + ". Interpolated values will be marked with '!'.")
+            print("Saving data to " + file_path + ". Interpolated values will be marked with '!'.")
         if verbose and not mark_interpolated:
-            print( "Saving data to " + file_path + ". Interpolated values will not be marked.")
+            print("Saving data to " + file_path + ". Interpolated values will not be marked.")
         with open(file_path, "wb") as f:
             f.seek(0)
             f.truncate()
             writer = csv.writer(f)
             for category, subjects in self.data_dict.iteritems():  # for every category in the data...
                 if verbose:
-                    print ("Saving category " + category + "...")
+                    print("Saving category " + category + "...")
                 #  write the header
                 writer.writerow([category])
                 if category == "Devices":
@@ -708,7 +718,7 @@ class Vicon(object):
                     writer.writerow(line)
                 writer.writerow(["", ""])
         if verbose:
-            print ("Saved!")
+            print("Saved!")
 
     def __eq__(self, other):
         return isinstance(other, Vicon) and self.data_dict == other.data_dict
@@ -718,42 +728,42 @@ class Vicon(object):
         Method to help find differences between different Vicon objects.
         """
         if not isinstance(other, Vicon):
-            print( "Not Vicon!")
+            print("Not Vicon!")
             return
-        print ("Scanning data for differences...")
+        print("Scanning data for differences...")
         flag = False
         for category, subjects in self.data_dict.iteritems():
             if category not in other.data_dict:
-                print ("Category " + category + " missing!")
+                print("Category " + category + " missing!")
                 flag = True
             for subject, fields in subjects.iteritems():
                 if subject not in other.data_dict[category]:
-                    print ("Subject " + subject + " in category " + category + " missing!")
+                    print("Subject " + subject + " in category " + category + " missing!")
                     flag = True
                 for field, f_vals in fields.iteritems():
                     if field not in other.data_dict[category][subject]:
                         flag = True
-                        print ("Field " + field + " of subject " + subject + " in category " + category + " missing!")
+                        print("Field " + field + " of subject " + subject + " in category " + category + " missing!")
                     elif len(f_vals["data"]) != len(other.data_dict[category][subject][field]["data"]):
                         flag = True
-                        print ("Data length mismatch in field " + field \
+                        print("Data length mismatch in field " + field \
                               + " of subject " + subject + " in category " + category + "!")
                     elif set(f_vals["data"]) != set(other.data_dict[category][subject][field]["data"]):
                         flag = True
-                        print ("Data mismatch in field " + field \
+                        print("Data mismatch in field " + field \
                               + " of subject " + subject + " in category " + category + "!")
                     elif f_vals["data"] != other.data_dict[category][subject][field]["data"]:
                         flag = True
-                        print ("Data order mismatch in field " + field \
+                        print("Data order mismatch in field " + field \
                               + " of subject " + subject + " in category " + category + "!")
 
                     if field in other.data_dict[category][subject] and f_vals["unit"] != \
                             other.data_dict[category][subject][field]["unit"]:
                         flag = True
-                        print ("Unit mismatch in field " + field \
+                        print("Unit mismatch in field " + field \
                               + " of subject " + subject + " in category " + category + "!")
         if not flag:
-            print ("No differences detected!")
+            print("No differences detected!")
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-GaitCore>=1.0
+GaitCore>=1.1

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ import setuptools
 setuptools.setup(
     name="Vicon",
     version="1.0",
-    install_requires=["GaitCore @ git+https://github.com/WPI_AIM/AIM_GaitCore.git"],
+    install_requires=["GaitCore>=1.1 @ git+https://github.com/WPI-AIM/AIM_GaitCore.git"],
     py_modules=["Vicon", "ModelOutput", "Markers", "IMU", "ForcePlate", "EMG", "Devices", "Accel"]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ import setuptools
 setuptools.setup(
     name="Vicon",
     version="1.0",
-    install_requires=["GaitCore>=1.1 @ git+https://github.com/WPI-AIM/AIM_GaitCore.git"],
+    install_requires=["GaitCore @ git+https://github.com/WPI-AIM/AIM_GaitCore.git"],
     py_modules=["Vicon", "ModelOutput", "Markers", "IMU", "ForcePlate", "EMG", "Devices", "Accel"]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,12 @@ import setuptools
 setuptools.setup(
     name="Vicon",
     version="1.0",
-    install_requires=["GaitCore @ git+https://github.com/WPI-AIM/AIM_GaitCore.git"],
+    install_requires=[
+        "GaitCore @ git+https://github.com/WPI-AIM/AIM_GaitCore.git",
+        "numpy",
+        "scipy",
+        "matplotlib",
+        "pandas"
+    ],
     py_modules=["Vicon", "ModelOutput", "Markers", "IMU", "ForcePlate", "EMG", "Devices", "Accel"]
 )


### PR DESCRIPTION
Added accurate joint calculations.

These methods differ from the previously `added calc_joint_center` method in a few ways:
 - Ball joints and hinge joints are treated separately, which allows for much simpler calculation for ball joints.
 - Joints are calculated while in their parent's reference frame. This allows for the joints to be treated as stationary, which is necessary for both the `calc_CoR` and `calc_AoR` methods to produce useful data.
 - Hinge joint locations are calculated using both the CoR and the AoR. The CoR, while somewhat accurate, is poorly defined on the AoR. Using the slope of the AoR and the estimated position of the CoR, the ``minimize_centers`` method can be used to find the point on the AoR closest to both the parent and child rigid bodies. This point, which corresponds to somewhere inside the knee, is then treated as the location of the joint.

There are a few limitations to the accuracy of these functions:
 - If a rigid body is missing any markers, it can have serious impacts on the accuracy of adjacent joints. For every dataset I tested on (`subject 00 Cal 01.csv`, `subject 00 Cal 02.csv`, `subject 02 Cal 01.csv`, `subject 03 Cal 03.csv`, and `subject 06 Cal 01.csv`), the right femur rigid body was missing data for at least one marker. (The marker appears in the spreadsheet, with field names and all, but the actual data is missing.) This causes the right hip and right knee locations to be horribly inaccurate, especially as the right femur changes orientation. This could possibly be solved by ignoring missing markers while creating the transformation matrices. (A side note - this issue is what led to the creation of the "sanitize" feature. If the missing data is not sanitized, it's represented by all NaNs, which then causes a crash while attempting to calculate the matrices.)
 - If a rigid body is misaligned with the part of leg it's on, even slightly, it can cause any immediately downleg joints to be highly inaccurate. This is most evident in the `subject 00 Cal 01.csv` file - in it, the left tibia rigid body is slightly misaligned with the actual shin, which causes the left ankle joint to be projected too far forwards. This is very likely unsolvable - it is a core requirement that the joints be calculated in their parent's frame of reference.
 - Similarly, brief changes in the position of even a single marker on a rigid body can impact the position of adjacent joints. This is most evident in the `subject 03 Cal 03.csv` file, where some of the markers on the hip rigid body twitch a few times. Each of these twitches causes massive, yet temporary, change in the represented position of the hip joints. As above, this is very likely unsolvable.